### PR TITLE
Providing possibility to launch rpivot without pyinstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Edit /etc/proxychains.conf:
 socks4 127.0.0.1 1080
 ```
 
+Using single zip file mode:
+
+```
+zip rpivot.zip -r *.py ./ntlm_auth/
+python rpivot.zip server <server_options>
+python rpivot.zip client <client_options> 
+```
+
 Pivot and have fun:
 
 `proxychains <tool_name>`

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import sys
+
+try:
+    rpivot_type = sys.argv.pop(1).lower()
+    if rpivot_type not in ('client', 'server'):
+        raise IndexError('Bad rpivot type')
+except IndexError:
+    print('{} <server|client> ...'.format(sys.argv[0]))
+    sys.exit(1)
+
+if rpivot_type == 'client':
+    import client
+    client.main()
+elif rpivot_type == 'server':
+    import server
+    server.main()

--- a/client.py
+++ b/client.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import logging
 import logging.handlers
 import socket

--- a/server.py
+++ b/server.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import logging
 import logging.handlers
 import socket


### PR DESCRIPTION
Added __main__.py to provide possibility to launch rpivot from the ZIP archive
Added shebang to client.py and server.py, so they can be launched directly (i.e. chmod +x ./client.py; ./client.py)
Updated README.md to describe new usage.

Partially solves #1 